### PR TITLE
Move django.wsgi and webroot outside project root

### DIFF
--- a/webroot/django.wsgi.template
+++ b/webroot/django.wsgi.template
@@ -1,15 +1,7 @@
 #!/usr/bin/env python
-import os, sys
+import os
 
-# path is the parent directory of this script ('/var/www' in this case)
-path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-
-# we check for path because we're told to at the tail end of
-# http://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIReloadMechanism
-if path not in sys.path:
-    sys.path.append(path)
+# PYTHONPATH should include the project root.
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'sikteeri.settings'
 


### PR DESCRIPTION
@guaq, @wraith,

We should make it clear that web root should not be the project root. This change moves the python path definition to mod_wsgi config, which is more logical.
