### PR TITLE
Add Git SHA1 hash to each response

### DIFF
--- a/sikteeri/GitVersionHeaderMiddleware.py
+++ b/sikteeri/GitVersionHeaderMiddleware.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+from version import VERSION
+
+class GitVersionHeaderMiddleware(object):
+    """
+    Set a X-Git-SHA1 header to the response
+
+    The X-Git-SHA1 header is intended to convey the deployed version
+    number of the project reliably.
+    """
+    def process_response(self, request, response):
+        response['X-Git-SHA1'] = VERSION
+        return response

--- a/sikteeri/settings.py
+++ b/sikteeri/settings.py
@@ -80,6 +80,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'sikteeri.ForceDefaultLanguageMiddleware.ForceDefaultLanguageMiddleware',
+    'sikteeri.GitVersionHeaderMiddleware.GitVersionHeaderMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 )


### PR DESCRIPTION
This is probably a better approach than the version number on the index page.
