### PR TITLE
fixed bug on comment printing

### DIFF
--- a/membership/templates/membership/membership_edit_inline.html
+++ b/membership/templates/membership/membership_edit_inline.html
@@ -111,7 +111,7 @@
 <h2>{% trans "Comments" %}</h2>
 {% get_comment_list for membership as comment_list %}
 {% for comment in comment_list %}
-    <p>{{ comment.submit_date|date:"j.n.Y" }} {{ comment }}</p>
+    <p>{{ comment.submit_date|date:"j.n.Y" }} {{ comment.comment }}</p>
 {% endfor %}
 
 {% get_comment_form for membership as commentform %}


### PR DESCRIPTION
Used comment.comment instead of comment. Calling class instead of message variable don't show long messages correctly.
