### PR TITLE
Django 1.4.0 => 1.4.3, gunicorn => 0.17.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django==1.4.0
-gunicorn==0.14.2
+Django==1.4.3
+gunicorn==0.17.2
 psycopg2==2.4.5


### PR DESCRIPTION
Tests pass.  gunicorn change logs don't indicate
any API breakage.

http://docs.gunicorn.org/en/latest/2012-news.html
and
http://docs.gunicorn.org/en/latest/2013-news.html
