### PR TITLE
http -> https fixes to prevent mixed content warnings

### DIFF
--- a/sikteeri/templates/base.html
+++ b/sikteeri/templates/base.html
@@ -6,7 +6,7 @@
     <title>Kapsin jäsentietojärjestelmä :: {{ title }}</title>
     <meta content="text/html;charset=utf-8" http-equiv="Content-type">
     <meta content="Kapsi Internet-käyttäjät ry" name="Author">
-    <link href="http://www.kapsi.fi/favicon.ico" type="image/x-icon" rel="shortcut icon">
+    <link href="https://www.kapsi.fi/favicon.ico" type="image/x-icon" rel="shortcut icon">
     <style media="screen" type="text/css">
         @import "{% static 'css/screen.css' %}";
         @import "{% static 'css/content.css' %}";
@@ -34,7 +34,7 @@
        <ul>
          <li><span class="currentpageitem">Jäsenhallinta</span></li>
          <li><hr></li>
-         <li><a href="http://www.kapsi.fi/">www.kapsi.fi</a></li>
+         <li><a href="https://www.kapsi.fi/">www.kapsi.fi</a></li>
        </ul>{% endif %}
        {% endblock %}
      </div>


### PR DESCRIPTION
Changed http:// urls to https:// versions to prevent mixed content warnings.