### PR TITLE
Fix validation of empty contact forms (technical, billing) in organization application

### DIFF
--- a/sikteeri/templates/base.html
+++ b/sikteeri/templates/base.html
@@ -54,7 +54,7 @@
      </div>
      {% block footer %}
      <div class="footer">
-       Copyright © Kapsi Internet-käyttäjät ry 2006–2014 ☕
+       Copyright © Kapsi Internet-käyttäjät ry 2006–2015 ☕
        {% if user.is_authenticated %}
      <div style="float: right; position: relative; bottom: 34px">
        <a href="http://djangopony.com/" class="ponybadge" title="Magic! Ponies! Django! Whee!">


### PR DESCRIPTION
Due to the addition of default-value for country-field, the non-filled form -logic broke in organization applicationextra contacts. This fixes it so that if only the country-field is changed, we consider the form empty.