### PR TITLE
Fix memberlist urls to include http:// prefix

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -19,8 +19,8 @@ HOW TO RUN
 source ~/env/sikteeri/bin/activate
 
 # Initialize development database
-./manage.py syncdb && \
 ./manage.py migrate && \
+./manage.py createsuperuser && \
 ./manage.py loaddata membership/fixtures/membership_fees.json && \
 ./manage.py generate_test_data
 

--- a/install-virtualenv.sh
+++ b/install-virtualenv.sh
@@ -47,5 +47,5 @@ source "${ENVDIR}/bin/activate"
 
 echo "Virtualenv environment $ENVDIR done"
 echo "To later activate the environment, type"
-echo "  source ~/env/sikteeri/bin/activate"
+echo "  source ${ENVDIR}/bin/activate"
 exit 0

--- a/membership/management/commands/generate_test_data.py
+++ b/membership/management/commands/generate_test_data.py
@@ -139,10 +139,15 @@ class Command(BaseCommand):
 
         person = Contact(**d)
         person.save()
+        if random() < 0.2:
+            public_memberlist = True
+        else:
+            public_memberlist = False
         membership = Membership(type='P', status='N',
                                 person=person,
                                 nationality='Finnish',
                                 municipality='Paska kaupunni',
+                                public_memberlist=public_memberlist,
                                 extra_info='Hintsunlaisesti semmoisia tietoja.')
 
         self.stdout.write(unicode(person))

--- a/membership/management/commands/public_memberlist.py
+++ b/membership/management/commands/public_memberlist.py
@@ -12,4 +12,4 @@ class Command(NoArgsCommand):
     def handle_noargs(self, **options):
         template_name = 'membership/public_memberlist.xml'
         data = public_memberlist_data()
-        return render_to_string(template_name, data).encode('utf-8')
+        return render_to_string(template_name, data)

--- a/membership/migrations/0003_ensure_http_prefix_contact_uris.py
+++ b/membership/migrations/0003_ensure_http_prefix_contact_uris.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    def ensure_http_prefix_contact(apps, schema_editor):
+        Contact = apps.get_model("membership", "Contact")
+        # Contacts with broken homepage field value
+        for contact in Contact.objects\
+                .exclude(homepage='')\
+                .exclude(homepage__startswith="http://")\
+                .exclude(homepage__startswith="https://"):
+            if contact.homepage:
+                if ":/" not in contact.homepage:
+                    contact.homepage = "http://{uri}".format(uri=contact.homepage)
+                    contact.save()
+
+    dependencies = [
+        ('membership', '0002_charfields_to_not_null'),
+    ]
+
+    operations = [
+        migrations.RunPython(ensure_http_prefix_contact)
+    ]

--- a/membership/models.py
+++ b/membership/models.py
@@ -92,6 +92,10 @@ class Contact(models.Model):
     homepage = models.URLField(blank=True, verbose_name=_('Homepage'))
 
     def save(self, *args, **kwargs):
+        if self.homepage:
+            if '://' not in self.homepage:
+                self.homepage = "http://{homepage}".format(homepage=self.homepage)
+
         if self.organization_name:
             if len(self.organization_name) < 5:
                 raise Exception("Organization's name should be at least 5 characters.")

--- a/membership/tests.py
+++ b/membership/tests.py
@@ -787,6 +787,34 @@ class TrustedHostTest(TestCase):
                 continue
             self.assertEqual(response.status_code, 200)
 
+
+class ContactTest(TestCase):
+
+    def test_short_homepage(self):
+        c = Contact(first_name="Aa", given_names="Aa", last_name="Bb")
+        c.homepage = "www.kapsi.fi"
+        c.save()
+        self.assertEqual(c.homepage, "http://www.kapsi.fi")
+
+    def test_short_homepage_create(self):
+        c = Contact.objects.create(first_name="Aa", given_names="Aa",
+            last_name="Bb", homepage = "www.kapsi.fi")
+        c = Contact.objects.get(pk=c.pk)
+        self.assertEqual(c.homepage, "http://www.kapsi.fi")
+
+    def test_proper_homepage(self):
+        c = Contact(first_name="Aa", given_names="Aa", last_name="Bb")
+        c.homepage = "http://www.kapsi.fi"
+        c.save()
+        self.assertEqual(c.homepage, "http://www.kapsi.fi")
+
+    def test_proper_secure_homepage(self):
+        c = Contact(first_name="Aa", given_names="Aa", last_name="Bb")
+        c.homepage = "https://www.kapsi.fi"
+        c.save()
+        self.assertEqual(c.homepage, "https://www.kapsi.fi")
+
+
 class MemberApplicationTest(TestCase):
     fixtures = ['membership_fees.json', 'test_user.json']
 

--- a/membership/tests.py
+++ b/membership/tests.py
@@ -822,6 +822,27 @@ class MemberApplicationTest(TestCase):
         self.assertEquals(new.person.first_name, u"Yrjö")
 
 
+    def test_do_application_with_short_homepage(self):
+        self.post_data['homepage'] = 'www.kapsi.fi'
+        response = self.client.post('/membership/application/person/', self.post_data)
+        self.assertRedirects(response, '/membership/application/person/success/')
+        new = Membership.objects.latest("id")
+        self.assertEquals(new.person.homepage, u"http://www.kapsi.fi")
+
+    def test_do_application_with_proper_homepage(self):
+        self.post_data['homepage'] = 'http://www.kapsi.fi'
+        response = self.client.post('/membership/application/person/', self.post_data)
+        self.assertRedirects(response, '/membership/application/person/success/')
+        new = Membership.objects.latest("id")
+        self.assertEquals(new.person.homepage, u"http://www.kapsi.fi")
+
+    def test_do_application_with_proper_secure_homepage(self):
+        self.post_data['homepage'] = 'https://www.kapsi.fi'
+        response = self.client.post('/membership/application/person/', self.post_data)
+        self.assertRedirects(response, '/membership/application/person/success/')
+        new = Membership.objects.latest("id")
+        self.assertEquals(new.person.homepage, u"https://www.kapsi.fi")
+
     def test_redundant_email_alias(self):
         self.post_data['unix_login'] = 'fnamelname'
         self.post_data['email_forward'] = 'fname.lname'


### PR DESCRIPTION
We seem to have 404s on public member list page due to bad data in database. Based on what I could figure out this should not be possible for new members for multiple reasons but I added tests and protective check just in case.

I believe this is actually now validated by both 1) modern browsers 2) Django URLField. We still need the migration to fix the existing data.

@annttu Please review.