### PR TITLE
Remove delete link when it’s not available

### DIFF
--- a/membership/templates/membership/membership_edit_inline.html
+++ b/membership/templates/membership/membership_edit_inline.html
@@ -59,8 +59,10 @@
   {% endif %}
 {% endif %}
 
-{% if perms.membership.delete_members and membership.status != "D" %}
+{% if perms.membership.delete_members %}
+{% if membership.status == "N" or membership.status == "P" or membership.status == "I" %}
   <a href="{% url "membership_delete" membership.id %}">{% trans "Delete" %}</a>
+{% endif %}
 {% endif %}
 
 {% if perms.membership.manage_members %}


### PR DESCRIPTION
Earlier clicking the link resulted in wrong state
resulted in an internal server error. Hide link.