### PR TITLE
Cancel outstanding bills when disassociating members

### DIFF
--- a/config-dev.json
+++ b/config-dev.json
@@ -16,6 +16,11 @@
 
   "BILL_ATTACH_PDF": true,
 
+  "BILLING_ACCOUNTING_MAP": {
+    "P": ["HJ", "9039"],
+    "O": ["YJ", "9037"],
+    "S": ["KJ", "9038"]
+  },
   "IBAN_ACCOUNT_NUMBER": "FI2112345600000785",
   "BIC_CODE": "NDEAFIHH",
   "BANK_NAME": "OP",

--- a/membership/billing/procountor_csv.py
+++ b/membership/billing/procountor_csv.py
@@ -1,0 +1,144 @@
+# encoding: UTF-8
+from __future__ import unicode_literals
+import csv
+import logging
+from datetime import datetime, timedelta
+from StringIO import StringIO
+from decimal import Decimal
+
+from django.conf import settings
+from membership.models import Bill, CancelledBill
+
+logger = logging.getLogger("procountor")
+
+type_mappings = {
+    'P': ['HJ', '9039'],
+    'O': ['YJ', '9037'],
+    'S': ['KJ', '9038']
+}
+
+
+def finnish_timeformat(t):
+    return t.strftime("%d.%m.%Y")
+
+
+ft = finnish_timeformat
+
+
+def _bill_to_rows(bill, cancel=False):
+    """Map bills to Procountor CSV format
+
+    http://support.procountor.com/fi/aineiston-sisaanluku/laskuaineiston-siirtotiedosto.html
+    """
+    rows = []
+    c = bill.billingcycle
+    if c.membership.type in ['H']:
+        return rows
+    rows.append([
+        'M',  # laskutyyppi
+        'EUR',  # valututakoodi
+        c.reference_number,  # viitenumero
+        settings.IBAN_ACCOUNT_NUMBER,  # pankkitili
+        '',  # Y-tunnus/HETU/ALV-tunnus
+        'tilisiirto',  # Maksutapa
+        c.membership.name(),  # Liikekumppanin nimi
+        '',  # Toimitustapa
+        '0',  # Laskun alennus %
+        't',  # Sis. alv koodi
+        'f' if cancel else 't',  # Hyvityslaskukoodi
+        '0.0',  # Viivästyskorko %
+        ft(bill.created),  # Laskun päivä
+        ft(bill.created),  # Toimituspäivämäärä
+        ft(bill.created + timedelta(days=settings.BILL_DAYS_TO_DUE)),  # Eräpäivämäärä
+        '',  # Liikekumppanin osoite
+        '%s\%s\%s\%s\%s' % (c.membership.name(),
+                            c.membership.get_billing_contact().street_address,
+                            c.membership.get_billing_contact().postal_code,
+                            c.membership.get_billing_contact().post_office,
+                            'FI'),  # Laskutusosoite
+        '',  # Toimitusosoite
+        '',  # Laskun lisätiedot
+        'Lasku %d sikteerissä, tuotu %s, jäsen %d' % (bill.id, ft(datetime.now()), c.membership.id),  # Muistiinpanto
+        c.membership.get_billing_contact().email,  # Sähköpostiosoite
+        '',  # Maksupäivämäärä
+        '',  # Valuuttakurssi
+        "%.2f" % Decimal.copy_negate(c.get_fee()) if cancel else c.get_fee(),  # Laskun loppusumma
+        "%d" % c.get_vat_percentage(),  # ALV-%
+        '6',  # Laskukanava
+        '',  # Verkkolaskutunnus
+        '%d' % bill.id,  # Tilausviite
+        't',  # Kirjanpito riveittäin -koodi)
+        '',  # Finvoice-osoite 1(ei enää käytössä)
+        '',  # Finvoice-osoite 2(ei enää käytössä)
+        '%d' % c.membership.id,  # Asiakasnumero
+        'X',  # Automaattinen lähetys tai maksettu muualla tieto
+        '',  # Liitetiedoston nimi ZIP-paketissa
+        '',  # Yhteyshenkilö
+        '',  # Liikekumppanin pankin SWIFT-tunnus
+        '',  # Verkkolaskuoperaattori
+        '',  # Liikekumppanin OVT-tunnus
+        "%s" % bill.id,  # Laskuttajan laskunumero
+        '',  # Faktoring-rahoitussopimuksen numero
+        '',  # ALV-käsittelyn maakoodi
+        '',  # Kielikoodi
+        '0',  # Käteisalennuksen päivien lukumäärä
+        '0'  # Käteisalennuksen prosentti
+    ])
+    member_type = type_mappings[c.membership.type]
+    r2 = ['',  # TYHJÄ
+          '',  # Tuotteen kuvaus
+          '%s%s' % (member_type[0], c.start.strftime("%y")),  # Tuotteen koodi
+          '-1' if cancel else '1',  # Määrä
+          '',  # Yksikkö
+          '%.2f' % c.get_fee(),  # Yksikköhinta
+          '0',  # Rivin alennusprosentti
+          "%d" % c.get_vat_percentage(),  # Rivin ALV-%
+          '',  # Rivikommentti
+          '',  # Tilausviite
+          '',  # Asiakkaan ostotilausnumero
+          '',  # Tilausvahvistusnumero
+          '',  # Lähetysluettelonumero
+          '%s' % member_type[1]  # Kirjanpitotili
+          ]
+    r2 += [''] * (len(rows[0]) - len(r2))
+    rows.append(r2)
+    return rows
+
+
+def create_csv(start=None):
+    """
+    Create procountor bill export csv
+    :return: path to csv file
+    """
+
+    if start is None:
+        start = datetime.now()
+        start = datetime(year=start.year, month=start.month(), day=1)
+
+    filehandle = StringIO()
+    output = csv.writer(filehandle, delimiter=b';', quoting=csv.QUOTE_NONE)
+
+    for bill in Bill.objects.filter(created__gte=start, reminder_count=0).all():
+        for row in _bill_to_rows(bill):
+            row2 = []
+            for v in row:
+                if type(v) == unicode:
+                    row2.append(v.encode("iso-8859-1"))
+                else:
+                    row2.append(v)
+            output.writerow(row2)
+
+    cancelled_bills = CancelledBill.objects.filter(exported=False)
+    for cb in cancelled_bills:
+        for row in _bill_to_rows(cb.bill, cancel=True):
+            row2 = []
+            for v in row:
+                if type(v) == unicode:
+                    row2.append(v.encode("iso-8859-1"))
+                else:
+                    row2.append(v)
+            output.writerow(row2)
+    cancelled_bills.update(exported=True)
+    logger.info("Marked all cancelled bills as exported.")
+
+    return filehandle.getvalue()

--- a/membership/billing/procountor_csv.py
+++ b/membership/billing/procountor_csv.py
@@ -105,7 +105,7 @@ def _bill_to_rows(bill, cancel=False):
     return rows
 
 
-def create_csv(start=None):
+def create_csv(start=None, mark_cancelled=True):
     """
     Create procountor bill export csv
     :return: path to csv file
@@ -138,7 +138,8 @@ def create_csv(start=None):
                 else:
                     row2.append(v)
             output.writerow(row2)
-    cancelled_bills.update(exported=True)
-    logger.info("Marked all cancelled bills as exported.")
+    if mark_cancelled:
+        cancelled_bills.update(exported=True)
+        logger.info("Marked all cancelled bills as exported.")
 
     return filehandle.getvalue()

--- a/membership/billing/procountor_csv.py
+++ b/membership/billing/procountor_csv.py
@@ -11,12 +11,6 @@ from membership.models import Bill, CancelledBill
 
 logger = logging.getLogger("membership.billing.procountor")
 
-type_mappings = {
-    'P': ['HJ', '9039'],
-    'O': ['YJ', '9037'],
-    'S': ['KJ', '9038']
-}
-
 
 def finnish_timeformat(t):
     return t.strftime("%d.%m.%Y")
@@ -84,7 +78,7 @@ def _bill_to_rows(bill, cancel=False):
         '0',  # Käteisalennuksen päivien lukumäärä
         '0'  # Käteisalennuksen prosentti
     ])
-    member_type = type_mappings[c.membership.type]
+    member_type = settings.BILLING_ACCOUNTING_MAP[c.membership.type]
     r2 = ['',  # TYHJÄ
           '',  # Tuotteen kuvaus
           '%s%s' % (member_type[0], c.start.strftime("%y")),  # Tuotteen koodi

--- a/membership/billing/procountor_csv.py
+++ b/membership/billing/procountor_csv.py
@@ -36,7 +36,7 @@ def _bill_to_rows(bill, cancel=False):
         return rows
     rows.append([
         'M',  # laskutyyppi
-        'EUR',  # valututakoodi
+        'EUR',  # valuuttakoodi
         c.reference_number,  # viitenumero
         settings.IBAN_ACCOUNT_NUMBER,  # pankkitili
         '',  # Y-tunnus/HETU/ALV-tunnus

--- a/membership/billing/procountor_csv.py
+++ b/membership/billing/procountor_csv.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from django.conf import settings
 from membership.models import Bill, CancelledBill
 
-logger = logging.getLogger("procountor")
+logger = logging.getLogger("membership.billing.procountor")
 
 type_mappings = {
     'P': ['HJ', '9039'],

--- a/membership/management/commands/procountor_export.py
+++ b/membership/management/commands/procountor_export.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+from __future__ import unicode_literals
+
+"""
+Copyright (c) 2014-2015 Kapsi Internet-käyttäjät ry. All rights reserved.
+
+Generates bill list in procountor format and emails it to relevant persons.
+"""
+
+import argparse
+from datetime import datetime
+import logging
+
+from django.core.management.base import BaseCommand
+from django.core import mail
+from django.conf import settings
+
+from membership.billing.procountor_csv import create_csv
+
+
+logger = logging.getLogger("procountor")
+
+
+def valid_date(s):
+    try:
+        return datetime.strptime(s, "%Y-%m-%d")
+    except ValueError:
+        msg = "Not a valid date: '{0}'.".format(s)
+        raise argparse.ArgumentTypeError(msg)
+
+
+class Command(BaseCommand):
+    help = 'Closes the specified poll for voting'
+
+    def add_arguments(self, parser):
+        parser.add_argument('-s', "--startdate", help="Start Date (YYYY-MM-DD)",
+                            default=None, type=valid_date)
+
+    def email_body(self):
+        return """Hei,
+
+Liitteenä sikteeristä tänään {date} lähteneet laskut Procountoriin vientiä varten.
+Mukana myös uudet hyvityslaskut.
+""".format(date=self.date_human())
+
+    @staticmethod
+    def date_human():
+        return datetime.now().strftime('%d.%m.%Y')
+
+    def handle(self, *args, **options):
+        start = options['startdate'] or datetime.now()
+        content = create_csv(datetime(year=start.year, month=start.month, day=start.day))
+        email = mail.EmailMessage(
+            subject='Sikteerin Procountor-vienti {date}'.format(date=self.date_human()),
+            body=self.email_body(),
+            from_email=settings.FROM_EMAIL,
+            to=[settings.BILLING_CC_EMAIL],
+            bcc=[])
+
+        # Send only if needed
+        if content:
+            email.attach('procountor-vienti-%s.csv' % start.strftime("%Y-%m-%d"), content, 'text/csv')
+            email.send()
+            message = "Sent Procountor bill list CSV by email"
+            logger.info(message)
+            self.stdout.write(message)
+        else:
+            message = "No messages to send"
+            logger.info(message)
+            self.stdout.write(message)
+        self.stdout.write("\n")

--- a/membership/management/commands/procountor_export.py
+++ b/membership/management/commands/procountor_export.py
@@ -20,7 +20,7 @@ from django.conf import settings
 from membership.billing.procountor_csv import create_csv
 
 
-logger = logging.getLogger("procountor")
+logger = logging.getLogger("membership.billing.procountor")
 
 
 def valid_date(s):

--- a/membership/management/commands/procountor_export.py
+++ b/membership/management/commands/procountor_export.py
@@ -56,7 +56,7 @@ Mukana myös uudet hyvityslaskut.
             subject='Sikteerin Procountor-vienti {date}'.format(date=self.date_human()),
             body=self.email_body(),
             from_email=settings.FROM_EMAIL,
-            to=[settings.BILLING_CC_EMAIL],
+            to=[settings.BILLING_FROM_EMAIL],
             bcc=[])
 
         # Send only if needed

--- a/membership/migrations/0005_cancelledbill.py
+++ b/membership/migrations/0005_cancelledbill.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('membership', '0004_make_phone_optional'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CancelledBill',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', models.DateTimeField(auto_now_add=True, verbose_name='Created')),
+                ('exported', models.BooleanField(default=False)),
+                ('bill', models.OneToOneField(verbose_name='Original bill', to='membership.Bill')),
+            ],
+        ),
+    ]

--- a/membership/models.py
+++ b/membership/models.py
@@ -828,7 +828,6 @@ class Bill(models.Model):
                 'street_address': membership.get_billing_contact().street_address,
                 'postal_code': membership.get_billing_contact().postal_code,
                 'post_office': membership.get_billing_contact().post_office,
-                'billing_contact': membership.billing_contact,
                 'billingcycle': self.billingcycle,
                 'iban_account_number': settings.IBAN_ACCOUNT_NUMBER,
                 'bic_code': settings.BIC_CODE,

--- a/membership/models.py
+++ b/membership/models.py
@@ -391,6 +391,8 @@ class Membership(models.Model):
                 bill = latest_billingcycle.first_bill()
                 if not bill.is_reminder():
                     CancelledBill.objects.get_or_create(bill=bill)
+                    logger.info("Created CancelledBill for Member #{member.pk} bill {bill.pk}".format(
+                        bill=bill, member=bill.billingcycle.membership))
         except ObjectDoesNotExist:
             return  # No billing cycle, no need to cancel bills
 

--- a/membership/tests.py
+++ b/membership/tests.py
@@ -521,6 +521,31 @@ class ProcountorExportTest(TestCase):
         csv_data = self.get_procountor_console()
         self.check_procountor_csv_format(csv_data)
 
+    def test_procountor_csv_format_organization_member(self):
+        membership = create_dummy_member('N', type='O')
+        membership.preapprove(self.user)
+        membership.approve(self.user)
+        makebills()
+        csv_data = self.get_procountor_console()
+        self.check_procountor_csv_format(csv_data)
+
+    def test_procountor_csv_format_supporting_member(self):
+        membership = create_dummy_member('N', type='S')
+        membership.preapprove(self.user)
+        membership.approve(self.user)
+        makebills()
+        csv_data = self.get_procountor_console()
+        self.check_procountor_csv_format(csv_data)
+
+    def test_procountor_csv_format_honorary_member(self):
+        membership = create_dummy_member('N', type='H')
+        membership.preapprove(self.user)
+        membership.approve(self.user)
+        makebills()
+        csv_data = self.get_procountor_console()
+        self.check_procountor_csv_format(csv_data)
+
+
     def check_procountor_csv_format(self, csv_data):
         bill_amounts = {}
         lineitem_totals = {}

--- a/sikteeri/settings.py
+++ b/sikteeri/settings.py
@@ -97,6 +97,7 @@ BILLING_FROM_EMAIL = get_required('BILLING_FROM_EMAIL')
 BILLING_CC_EMAIL = config.get('BILLING_CC_EMAIL')
 BILL_SUBJECT = get_required('BILL_SUBJECT')
 REMINDER_SUBJECT = get_required('REMINDER_SUBJECT')
+BILLING_ACCOUNTING_MAP = get_required('BILLING_ACCOUNTING_MAP')
 
 # Send bills how many days before new cycle starts
 BILL_DAYS_BEFORE_CYCLE = int(get_required('BILL_DAYS_BEFORE_CYCLE'))


### PR DESCRIPTION
If latest billing cycle is unpaid when member is disassociated, create a record that cancels the bill.

This is work in progress – should still add unit tests and add to repo the CSV export script that marks exported=True once the information has been recorded outside sikteeri.