### PR TITLE
Make tests predictable

### DIFF
--- a/membership/models.py
+++ b/membership/models.py
@@ -767,7 +767,9 @@ class Bill(models.Model):
     def save(self, *args, **kwargs):
         if not self.due_date:
             self.due_date = datetime.now() + timedelta(days=settings.BILL_DAYS_TO_DUE)
-            self.due_date = self.due_date.replace(hour=23, minute=59, second=59)
+            # Second is from reminder_count so that tests can assume due_date
+            # is monotonically increasing
+            self.due_date = self.due_date.replace(hour=23, minute=59, second=self.reminder_count % 60)
         super(Bill, self).save(*args, **kwargs)
 
     def is_reminder(self):

--- a/membership/test_utils.py
+++ b/membership/test_utils.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
-from random import choice, randint
 import logging
+from random import Random
+
+# Use predictable random for consistent tests
+random = Random()
+random.seed(1)
 
 logger = logging.getLogger("membership.test_utils")
-
 
 # Finnish population register center's most popular first names for year 2009
 from membership.models import Membership, Contact
@@ -155,17 +158,18 @@ last_names = [
     u"Äijänen", u"Ärmänen"]
 
 def random_first_name():
-    return choice(first_names)
+    return random.choice(first_names)
 
 def random_last_name():
-    return choice(last_names)
+    return random.choice(last_names)
+
 
 def create_dummy_member(status, type='P', mid=None):
     if status not in ['N', 'P', 'A']:
         raise Exception("Unknown membership status")
     if type not in ['P', 'S', 'O', 'H']:
         raise Exception("Unknown membership type")
-    i = randint(1, 300)
+    i = random.randint(1, 300)
     fname = random_first_name()
     d = {
         'street_address' : 'Testikatu %d'%i,

--- a/membership/test_utils.py
+++ b/membership/test_utils.py
@@ -8,9 +8,13 @@ random.seed(1)
 
 logger = logging.getLogger("membership.test_utils")
 
-# Finnish population register center's most popular first names for year 2009
 from membership.models import Membership, Contact
 
+
+# We use realistic names in test data so that it is feasible to test
+# duplicate member detection code locally without using production data.
+
+# Finnish population register center's most popular first names for year 2009
 first_names = [
     u"Maria", u"Juhani", u"Aino", u"Veeti", u"Emilia", u"Johannes", u"Venla",
     u"Eetu", u"Sofia", u"Mikael", u"Emma", u"Onni", u"Olivia", u"Matias",


### PR DESCRIPTION
Our tests could fail at a low, non-deterministic rate. Here are some fixes that make tests deterministic.

Ready for merge.