### PR TITLE
Allow empty phone numbers

### DIFF
--- a/membership/migrations/0004_make_phone_optional.py
+++ b/membership/migrations/0004_make_phone_optional.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('membership', '0003_ensure_http_prefix_contact_uris'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contact',
+            name='phone',
+            field=models.CharField(max_length=64, verbose_name='Phone', blank=True),
+        ),
+    ]

--- a/membership/models.py
+++ b/membership/models.py
@@ -98,7 +98,7 @@ class Contact(models.Model):
     postal_code = models.CharField(max_length=10, verbose_name=_('Postal code'))
     post_office = models.CharField(max_length=128, verbose_name=_('Post office'))
     country = models.CharField(max_length=128, verbose_name=_('Country'))
-    phone = models.CharField(max_length=64, verbose_name=_('Phone'))
+    phone = models.CharField(max_length=64, blank=True, verbose_name=_('Phone'))
     sms = models.CharField(max_length=64, blank=True, verbose_name=_('SMS number'))
     email = models.EmailField(blank=True, verbose_name=_('E-mail'))
     homepage = models.URLField(blank=True, verbose_name=_('Homepage'))

--- a/membership/models.py
+++ b/membership/models.py
@@ -421,26 +421,31 @@ class Membership(models.Model):
         numbers and contact details.  Returns a QuerySet object that doesn't
         include the membership of which duplicates are search for itself.
         """
-        qs = Membership.objects
+        matches = Membership.objects.none()
 
         if self.person and not self.organization:
-            name_q = Q(person__first_name__icontains=self.person.first_name.strip(),
-                       person__last_name__icontains=self.person.last_name.strip())
+            # Matches by first or last name
+            matches |= Membership.objects.filter(
+                person__first_name__icontains=self.person.first_name.strip(),
+                person__last_name__icontains=self.person.last_name.strip())
 
-            email_q = Q(person__email__contains=self.person.email.strip())
-            phone_q = Q(person__phone__icontains=self.person.phone.strip())
-            sms_q = Q(person__sms__icontains=self.person.sms.strip())
-            # don't match empty sms string
-            if self.person.sms.strip():
-                contacts_q = email_q | phone_q | sms_q
-            else:
-                contacts_q = email_q | phone_q
+            # Matches by email address
+            matches |= Membership.objects.filter(
+                person__email__contains=self.person.email.strip())
 
-            qs = qs.filter(name_q | contacts_q)
+            # Matches by phone or SMS number
+            phone_number = self.person.phone.strip()
+            sms_number = self.person.sms.strip()
+            if phone_number:
+                matches |= Membership.objects.filter(person__phone__icontains=phone_number)
+            if sms_number:
+                matches |= Membership.objects.filter(person__sms__icontains=sms_number)
         elif self.organization and not self.person:
-            qs = qs.filter(organization__organization_name__icontains=self.organization.organization_name.strip())
+            organization_name = self.organization.organization_name.strip()
+            matches = Membership.objects.filter(
+                organization__organization_name__icontains=organization_name)
 
-        return qs.exclude(id__exact=self.id)
+        return matches.exclude(id=self.id)
 
     @classmethod
     def search(cls, query):

--- a/membership/tests.py
+++ b/membership/tests.py
@@ -1296,6 +1296,19 @@ class DuplicateMembershipDetectionTest(TestCase):
 
         self.assertEquals(len(m1.duplicates()), 1)
 
+    def test_empty_phone_is_not_duplicate(self):
+        m1 = create_dummy_member('N')
+        m1.save()
+        m1.person.phone = ''
+        m1.person.save()
+
+        m2 = create_dummy_member('N')
+        m2.save()
+        m2.person.phone = ''
+        m2.person.save()
+
+        self.assertEquals(len(m1.duplicates()), 0)
+
 
 class MembershipSearchTest(TestCase):
     def setUp(self):

--- a/membership/tests.py
+++ b/membership/tests.py
@@ -13,6 +13,7 @@ from django.contrib.auth.models import User
 from django.core import mail
 from django.test import TestCase
 from django.http import HttpResponse, HttpRequest
+from django.utils.translation import ugettext_lazy as _
 
 import email_utils
 from models import *
@@ -823,6 +824,18 @@ class MemberApplicationTest(TestCase):
         self.assertRedirects(response, '/membership/application/person/success/')
         new = Membership.objects.latest("id")
         self.assertEquals(new.person.homepage, u"http://www.kapsi.fi")
+
+    def test_do_application_with_empty_phone_number(self):
+        self.post_data['phone'] = ''
+        response = self.client.post('/membership/application/person/', self.post_data)
+        self.assertEquals(response.status_code, 200)
+        self.assertFormError(response, 'form', 'phone', _('This field is required.'))
+
+    def test_do_application_with_empty_sms_number(self):
+        self.post_data['sms'] = ''
+        response = self.client.post('/membership/application/person/', self.post_data)
+        self.assertEquals(response.status_code, 200)
+        self.assertFormError(response, 'form', 'sms', _('This field is required.'))
 
     def test_do_application_with_proper_homepage(self):
         self.post_data['homepage'] = 'http://www.kapsi.fi'


### PR DESCRIPTION
From IRC. We should be able to clear phone numbers in case member does not want to use a phone number. It's still required in application form (as tested now explicitly).