### PR TITLE
Only bills for the approved members should show in membership metrics.

### DIFF
--- a/membership/views.py
+++ b/membership/views.py
@@ -1043,7 +1043,7 @@ def test_email(request, template_name='membership/test_email.html'):
 
 @trusted_host_required
 def membership_metrics(request):
-    unpaid_cycles = BillingCycle.objects.filter(is_paid=False)
+    unpaid_cycles = BillingCycle.objects.filter(membership__status='A', is_paid=False)
     unpaid_sum = unpaid_cycles.aggregate(Sum("sum"))['sum__sum']
     if unpaid_sum == None:
         unpaid_sum = "0.0"


### PR DESCRIPTION
Nowadays every open bill is shown as open in metrics which is wrong because there is many open bills belonging to dissociated members or even deleted members in database. 