### PR TITLE
Update description for unix account field

### DIFF
--- a/membership/email_utils.py
+++ b/membership/email_utils.py
@@ -22,7 +22,7 @@ def unix_email(membership):
     if settings.UNIX_EMAIL_DOMAIN:
         from services.models import valid_aliases, Alias
         try:
-            alias = valid_aliases(membership).filter(account=True).latest('created')
+            alias = valid_aliases(membership).filter(account=True).earliest('created')
             email = u"{user}@{domain}".format(user=alias, domain=settings.UNIX_EMAIL_DOMAIN)
             return format_email(name=membership.name(), email=email)
         except Alias.DoesNotExist:

--- a/services/models.py
+++ b/services/models.py
@@ -68,7 +68,7 @@ class ServiceType(models.Model):
 class Alias(models.Model):
     owner = models.ForeignKey('membership.Membership', verbose_name=_('Alias owner'))
     name = models.CharField(max_length=128, unique=True, verbose_name=_('Alias name'))
-    account = models.BooleanField(default=False, verbose_name=_('Is UNIX account'))
+    account = models.BooleanField(default=False, verbose_name=_('Is primary member account, e.g. fall-back address for reminders'))
     created = models.DateTimeField(auto_now_add=True, verbose_name=_('Created'))
     comment = models.CharField(max_length=128, blank=True, verbose_name=_('Comment'))
     expiration_date = models.DateTimeField(blank=True, null=True, verbose_name=_('Alias expiration date'))


### PR DESCRIPTION
Unix account is actually the primary account for the user, and is used as
a fall-back address for sending reminders. There should only be one
alias marked primary per member.