### PR TITLE
truncate payment message length to 255 characters

### DIFF
--- a/membership/billing/payments.py
+++ b/membership/billing/payments.py
@@ -225,7 +225,7 @@ def row_to_payment(row):
                     type=row['event_type_description'],
                     payer_name=row['fromto'],
                     reference_number=row['reference'],
-                    message=row['message'],
+                    message=row['message'][:255],
                     transaction_id=row['transaction'])
     return p
 


### PR DESCRIPTION
Some payments have message length longer than maximum message length allowed in database.
Truncate payment message length to 255 characters.