### PR TITLE
Remove debug prints from search

### DIFF
--- a/membership/models.py
+++ b/membership/models.py
@@ -471,11 +471,9 @@ class Membership(models.Model):
 
         # Split into words and remove duplicates
         words = set(query.split(" "))
-        print(words)
         # Each word narrows the search further
         for word in words:
             # Exact match for membership id (for Django admin)
-            print("word: %s" % word)
             if word.startswith('#'):
                 try:
                     mid = int(word[1:])


### PR DESCRIPTION
Printing search tokens with non ascii characters throws UnicodeEncodeError.