### PR TITLE
Fix IpRangeList with long IPv6 addresses

### DIFF
--- a/membership/tests.py
+++ b/membership/tests.py
@@ -1759,6 +1759,21 @@ class IpRangeListTest(TestCase):
         self.assertTrue('1.2.3.4' in IpRangeList(*iplist))
         self.assertFalse('127.0.0.1' in IpRangeList())
 
+    def test_rangelist_IPv4(self):
+        a = IpRangeList("1.1.1.1")
+        self.assertTrue("1.1.1.1" in a)
+
+    def test_rangelist_IPv6(self):
+        a = IpRangeList("::1", "2001:8db:1234:1234:1234:da:1:2", "2001:8db:1234:1234::2")
+        self.assertTrue("0:0:0:0:0:0:0:1" in a)
+        self.assertTrue("2001:8db:1234:1234:1234:da:1:2" in a)
+        self.assertTrue("2001:8db:1234:1234:0:0:0:2" in a)
+
+    def test_rangelist_IPv4_and_IPv6(self):
+        a = IpRangeList("::1",  "1.1.1.1")
+        self.assertTrue("0:0:0:0:0:0:0:1" in a)
+        self.assertTrue("1.1.1.1" in a)
+
 
 @trusted_host_required
 def dummyView(request, *args, **kwargs):

--- a/sikteeri/iptools.py
+++ b/sikteeri/iptools.py
@@ -6,6 +6,7 @@
 import socket
 import struct
 
+
 def ipv6_to_long(ip):
     """Return the IPv6 address string as a long
 
@@ -18,6 +19,7 @@ def ipv6_to_long(ip):
     ip_parts = struct.unpack('!QQ', ip_bytes_n)
     return 2**64 * ip_parts[0] + ip_parts[1]
 
+
 def ipv4_to_long(ip):
     """Return the IPv4 address string as a long
 
@@ -28,6 +30,7 @@ def ipv4_to_long(ip):
     """
     ip_bytes_n = socket.inet_pton(socket.AF_INET, ip)
     return int(struct.unpack('!I', ip_bytes_n)[0])
+
 
 def long_to_ipv4(ip_long):
     """Convert a long representation to a human readable IPv4 string
@@ -40,6 +43,7 @@ def long_to_ipv4(ip_long):
     ip_bytes = struct.pack("!I", ip_long)
     return socket.inet_ntop(socket.AF_INET, ip_bytes)
 
+
 def long_to_ipv6(ip_long):
     """Convert a long representation to a human readable IPv6 string
 
@@ -48,9 +52,10 @@ def long_to_ipv6(ip_long):
     >>> long_to_ipv6(1L)
     '::1'
     """
-    ip_parts = (ip_long/2**64, ip_long % 2**64)
+    ip_parts = (int(ip_long/2**64), int(ip_long % 2**64))
     ip_bytes = struct.pack("!QQ", *ip_parts)
     return socket.inet_ntop(socket.AF_INET6, ip_bytes)
+
 
 def ipv4_mask_to_long(mask):
     """Convert an IPv4 netmax (prefixlen) to long
@@ -63,6 +68,7 @@ def ipv4_mask_to_long(mask):
     mask_binary = ("1" * mask) + ("0" * (32-mask))
     return int(mask_binary, 2)
 
+
 def ipv6_mask_to_long(mask):
     """Convert an IPv6 prefixlen to long
 
@@ -73,6 +79,7 @@ def ipv6_mask_to_long(mask):
     """
     mask_binary = ("1" * mask) + ("0" * (128-mask))
     return int(mask_binary, 2)
+
 
 def cidr_to_network(ip, prefixlen):
     """Calculate the network address for a CIDR notation network
@@ -93,6 +100,7 @@ def cidr_to_network(ip, prefixlen):
         network_long = ip_long & netmask
         network = long_to_ipv4(network_long)
     return network
+
 
 class IpRangeList:
     """IP range list that supports CIDR notation for IPv4 and IPv6
@@ -130,6 +138,7 @@ class IpRangeList:
             prefixlen = int(prefixlen)
             network = cidr_to_network(ip, prefixlen)
             self._masks.append((network, prefixlen))
+
     def __contains__(self, x):
         for (network, prefixlen) in self._masks:
             x_network = None
@@ -141,17 +150,20 @@ class IpRangeList:
                 return True
         return False
 
+
 def load_tests(loader, tests, pattern):
     import doctest
     suite = doctest.DocTestSuite()
     tests.addTests(suite)
     return suite
 
+
 def main():
     import unittest
     import doctest
     suite = doctest.DocTestSuite()
     unittest.TextTestRunner().run(suite)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Python2 to 3 migration broke trusted ip address verification checks in some cases.
Fix check when long (numerically big) IPv6 addresses are used.