### PR TITLE
Replace registration numbers with Business ID and show first and last name in organization member bills

### DIFF
--- a/membership/billing/pdf.py
+++ b/membership/billing/pdf.py
@@ -220,6 +220,15 @@ class PDFTemplate(object):
         membercontact = cycle.membership.get_billing_contact()
         amount_paid = 0
 
+        if membercontact.organization_name and (membercontact.first_name or membercontact.last_name):
+            name = "{organization_name}\n{first_name} {last_name}".format(
+                organization_name = membercontact.organization_name,
+                first_name = membercontact.first_name,
+                last_name = membercontact.last_name
+            )
+        else:
+            name = cycle.membership.name()
+
         # Calculate vat; copied from models.Bill#render_as_text(self)
         vat = Decimal(cycle.get_vat_percentage()) / Decimal(100)
         if self.__type__ == 'reminder':
@@ -284,7 +293,7 @@ class PDFTemplate(object):
         else:
             latest_payments = datetime.now()
         self.data = {
-            'name': cycle.membership.name(),
+            'name': name,
             'address': membercontact.street_address,
             'postal_code': membercontact.postal_code,
             'postal_office': membercontact.post_office.upper(),

--- a/membership/forms.py
+++ b/membership/forms.py
@@ -117,9 +117,9 @@ class OrganizationMembershipForm(forms.Form):
                                    label=_('Home municipality'),
                                    help_text=_('Place where your organization is registered to'))
     organization_registration_number = OrganizationRegistrationNumber(
-                                 label=_('Organization registration number'),
+                                 label=_('Business ID'),
                                  required=True,
-                                 help_text=_('Registration number given by Patentti- ja rekisterihallitus'))
+                                 help_text=_('Business ID given by Patentti- ja rekisterihallitus'))
     extra_info = forms.CharField(label=_('Additional information'),
                                  widget=forms.Textarea(attrs={'cols': '40'}),
                                  required=False,

--- a/membership/locale/fi/LC_MESSAGES/django.po
+++ b/membership/locale/fi/LC_MESSAGES/django.po
@@ -139,8 +139,8 @@ msgid "Place where your organization is registered to"
 msgstr "Kotipaikka (säännöissä)"
 
 #: membership/forms.py:112 membership/models.py:219
-msgid "Organization registration number"
-msgstr "Yhdistysrekisterinumero"
+msgid "Business ID"
+msgstr "Y-tunnus"
 
 #: membership/forms.py:114
 msgid "Registration number given by Patentti- ja rekisterihallitus"

--- a/membership/locale/fi/LC_MESSAGES/djangojs.po
+++ b/membership/locale/fi/LC_MESSAGES/djangojs.po
@@ -55,8 +55,8 @@ msgid "Year of birth"
 msgstr "Syntymävuosi"
 
 #: static/js/member_list.js:64
-msgid "Organization registration number"
-msgstr "Yhdistysrekisterinumero"
+msgid "Business ID"
+msgstr "Y-tunnus"
 
 #: static/js/member_list.js:65
 msgid "Services"

--- a/membership/migrations/0001_initial.py
+++ b/membership/migrations/0001_initial.py
@@ -89,7 +89,7 @@ class Migration(migrations.Migration):
                 ('municipality', models.CharField(max_length=128, verbose_name='Home municipality', blank=True)),
                 ('nationality', models.CharField(max_length=128, verbose_name='Nationality')),
                 ('birth_year', models.IntegerField(null=True, verbose_name='Year of birth', blank=True)),
-                ('organization_registration_number', models.CharField(max_length=15, null=True, verbose_name='Organization registration number', blank=True)),
+                ('organization_registration_number', models.CharField(max_length=15, null=True, verbose_name='Business ID', blank=True)),
                 ('extra_info', models.TextField(verbose_name='Additional information', blank=True)),
                 ('locked', models.DateTimeField(null=True, verbose_name='Membership locked', blank=True)),
                 ('dissociation_requested', models.DateTimeField(null=True, verbose_name='Dissociation requested', blank=True)),

--- a/membership/migrations/0002_charfields_to_not_null.py
+++ b/membership/migrations/0002_charfields_to_not_null.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='membership',
             name='organization_registration_number',
-            field=models.CharField(default='', max_length=15, verbose_name='Organization registration number', blank=True),
+            field=models.CharField(default='', max_length=15, verbose_name='Business ID', blank=True),
             preserve_default=False,
         ),
         migrations.AlterField(

--- a/membership/models.py
+++ b/membership/models.py
@@ -228,7 +228,7 @@ class Membership(models.Model):
     municipality = models.CharField(_('Home municipality'), max_length=128, blank=True)
     nationality = models.CharField(_('Nationality'), max_length=128)
     birth_year = models.IntegerField(_('Year of birth'), null=True, blank=True)
-    organization_registration_number = models.CharField(_('Organization registration number'),
+    organization_registration_number = models.CharField(_('Business ID'),
                                                         blank=True, max_length=15)
 
     person = models.ForeignKey('Contact', related_name='person_set', verbose_name=_('Person'), blank=True, null=True)

--- a/membership/static/js/member_list.js
+++ b/membership/static/js/member_list.js
@@ -61,7 +61,7 @@ function makeMembershipDetailObject(id) {
 	addRow(obj.table, gettext("Visible in the public memberlist"), "public_memberlist");
 	addRow(obj.table, gettext("Aliases"), "aliases");
 	addRow(obj.table, gettext("Year of birth"), "birth_year");
-	addRow(obj.table, gettext("Organization registration number"), "organization_registration_number");
+	addRow(obj.table, gettext("Business ID"), "organization_registration_number");
 	addRow(obj.table, gettext("Services"), "services");
 	addRow(obj.table, gettext("Additional information"), "extra_info");
     }


### PR DESCRIPTION
The registration numbers recorded in the Register of Associations are no longer in use.