### PR TITLE
Change org.reg.no. regex to business-ID (Y-tunnus)

### DIFF
--- a/membership/forms.py
+++ b/membership/forms.py
@@ -47,8 +47,8 @@ class PhoneNumberField(forms.RegexField):
 
 class OrganizationRegistrationNumber(forms.RegexField):
     def __init__(self, *args, **kwargs):
-        super(OrganizationRegistrationNumber, self).__init__(regex=r"^\d{7}-?\d$",
-                                                             min_length=8, max_length=9, *args, **kwargs)
+        super(OrganizationRegistrationNumber, self).__init__(regex=r"^ *[\d]{7}-?\d *$",
+                                                             min_length=8, max_length=20, *args, **kwargs)
 
     def clean(self, value):
         return super(OrganizationRegistrationNumber, self).clean(value).replace(" ", "")

--- a/membership/forms.py
+++ b/membership/forms.py
@@ -47,8 +47,8 @@ class PhoneNumberField(forms.RegexField):
 
 class OrganizationRegistrationNumber(forms.RegexField):
     def __init__(self, *args, **kwargs):
-        super(OrganizationRegistrationNumber, self).__init__(regex=r"^ *[\d]{1,4}\.[\d]{1,4} *$",
-                                                             min_length=4, max_length=14, *args, **kwargs)
+        super(OrganizationRegistrationNumber, self).__init__(regex=r"^\d{7}-?\d$",
+                                                             min_length=8, max_length=9, *args, **kwargs)
 
     def clean(self, value):
         return super(OrganizationRegistrationNumber, self).clean(value).replace(" ", "")


### PR DESCRIPTION
As registration numbers are obsolete and everything goes by Business ID (Y-tunnus) now, this change checks for Business ID format, accepts 7+1 digits with or without dash before last digit.

Signed-off-by: Sami Olmari <sami@olmari.fi>