### PR TITLE
Fix null name file handling in payment import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.6"
 before_script:
  - "sudo locale-gen fi_FI.UTF-8"
- - "pip install pytest-coverage pytest-django codecov"
+ - "pip install 'pytest>=5.0' pytest-coverage pytest-django codecov"
 script: "./test.sh"
 sudo: required
 after_success:

--- a/membership/billing/procountor_api.py
+++ b/membership/billing/procountor_api.py
@@ -74,7 +74,7 @@ class ProcountorBankStatementEvent(object):
             self.valueDate = datetime.strptime(self.valueDate, "%Y-%m-%d")
         self.sum = row.get("sum", 0)
         self.accountNumber = row.get("accountNumber", None)
-        self.name = row.get("name", None)
+        self.name = row.get("name", None) or ""  # Force name to be string
         self.explanationCode = row.get("explanationCode", 0)
         self.explanationDescription = self.EXPLANATIONCODES.get(self.explanationCode,
                                                                 str(self.explanationCode))

--- a/membership/test_data/procountor-csv-null-fields.csv
+++ b/membership/test_data/procountor-csv-null-fields.csv
@@ -1,0 +1,2 @@
+Arvopäivä;Maksupäivä;Summa;Kirjausselite;Nimi;Tilinro;Viitenumero;Viesti;Kohdistettu;Arkistointitunnus
+16.06.2020;16.06.2020;0,55;700 Peruutus;;;;00123123 PALVELUMAKSUN PALAUTUS;;20000000 AL 123123

--- a/membership/tests.py
+++ b/membership/tests.py
@@ -1115,6 +1115,12 @@ class ProcountorCSVReadingTest(TestCase):
             except RequiredFieldNotFoundException:
                 self.fail("Valid csv should not raise header error.")
 
+    def test_csv_with_null_fields(self):
+        with open_test_data("procountor-csv-null-fields.csv") as f:
+            process_procountor_csv(f)
+        payment_count = Payment.objects.count()
+        self.assertEqual(payment_count, 1, "CSV should have contained 1 payment")
+
 
 class LoginRequiredTest(TestCase):
     fixtures = ['membership_fees.json', 'test_user.json']


### PR DESCRIPTION
Procountor API gave us null name field and payment import failed.
This fixes null name field handling.
 